### PR TITLE
AnaloguePositionX and AnaloguePositionY commands

### DIFF
--- a/lua/analogue/command.lua
+++ b/lua/analogue/command.lua
@@ -20,13 +20,13 @@ local function position_command()
 	a.nvim_create_user_command(
 		'AnaloguePosition',
 		function(props)
-			if util.includes(config.win_positions, props.args) then
-				M._module.fixed_position = props.args -- update cache for reset command to function
-
+			if util.includes(config.win_fixed_positions_keys, props.args, true) then
+				local pos = config.get_win_position(props.args)
+				M._module.fixed_position = props.args
 				a.nvim_win_set_config(M._module.win, {
 					relative = 'editor',
-					row = config.win_positions[props.args].row,
-					col = config.win_positions[props.args].col,
+					row = pos.row,
+					col = pos.col,
 				})
 			else
 				a.nvim_err_writeln("Unknown position value")

--- a/lua/analogue/command.lua
+++ b/lua/analogue/command.lua
@@ -18,6 +18,32 @@ local M = {}
 ---@field adjusted_position? AdjustedPosition user-adjusted exact position of the clock
 M._module = {}
 
+-- Creates `:AnaloguePositionY {num}` custom command.
+-- Argument `{num}` must be a number.
+---@return nil
+local function position_y_command()
+	a.nvim_create_user_command(
+		'AnaloguePositionY',
+		function(props)
+			local inputY = tonumber(props.args)
+			if inputY == nil then
+				a.nvim_err_writeln("Argument must be number")
+			else
+				local pos = config.get_win_position(M._module.fixed_position)
+				M._module.adjusted_position.y = M._module.adjusted_position.y + inputY
+				a.nvim_win_set_config(M._module.win, {
+					relative = 'editor',
+					row = M._module.adjusted_position.y,
+					col = pos.col,
+				})
+			end
+		end,
+		{
+			nargs = 1
+		}
+	)
+end
+
 -- Creates `:AnaloguePositionX {num}` custom command.
 -- Argument `{num}` must be a number.
 ---@return nil
@@ -155,6 +181,7 @@ function M.register_commands(props)
 	open_command()
 	position_command()
 	position_x_command()
+	position_y_command()
 end
 
 return M

--- a/lua/analogue/command.lua
+++ b/lua/analogue/command.lua
@@ -54,6 +54,7 @@ local function position_command()
 			if util.includes(config.win_fixed_positions_keys, props.args, true) then
 				local pos = config.get_win_position(props.args)
 				M._module.fixed_position = props.args
+				M._module.adjusted_position = { x = pos.col, y = pos.row }
 				a.nvim_win_set_config(M._module.win, {
 					relative = 'editor',
 					row = pos.row,
@@ -76,11 +77,10 @@ local function reset_command()
 		'AnalogueReset',
 		function()
 			local pos = config.get_win_position(M._module.fixed_position)
-			M._module.adjusted_position.x = pos.col
 			a.nvim_win_set_config(M._module.win, {
 				relative = 'editor',
 				row = pos.row,
-				col = pos.col,
+				col = M._module.adjusted_position.x
 			})
 		end,
 		{

--- a/lua/analogue/config.lua
+++ b/lua/analogue/config.lua
@@ -6,14 +6,15 @@ local height = 11
 ---@param pos string
 ---@return table
 function M.get_win_position(pos)
+	-- heigt_of_the_lualine = 4
 	if pos == "bottom-right" then
 		return {
-			row = vim.o.lines - height,
+			row = vim.o.lines - height - 4,
 			col = vim.o.columns - width,
 		}
 	elseif pos == "bottom-left" then
 		return {
-			row = vim.o.lines - height,
+			row = vim.o.lines - height - 4,
 			col = 1,
 		}
 	elseif pos == "top-right" then
@@ -28,7 +29,7 @@ function M.get_win_position(pos)
 		}
 	else -- defaults to bottom-right
 		return {
-			row = vim.o.lines - height,
+			row = vim.o.lines - height - 4,
 			col = vim.o.columns - width,
 		}
 	end

--- a/lua/analogue/config.lua
+++ b/lua/analogue/config.lua
@@ -34,6 +34,13 @@ function M.get_win_position(pos)
 	end
 end
 
+M.win_fixed_positions_keys = {
+	"bottom-right",
+	"bottom-left",
+	"top-right",
+	"top-left",
+}
+
 M.constants = {
 	width = width,
 	height = height

--- a/lua/analogue/util.lua
+++ b/lua/analogue/util.lua
@@ -2,17 +2,28 @@
 
 local M = {}
 
---Returns true if record contains a property with provided key
----@param record table A table with keys of type string
----@param key string Key to check for its presence
+--Returns true if table contains a key/value with provided string value.
+--If `isArray` is true table is considered an array so array items are checked. Otherwise it's considered an object-like table and its keys are checked.
+---@param table table A table with keys of type string
+---@param value string Value to check for its presence
+---@param isArray boolean 
 ---@return boolean
-function M.includes(record, key)
+function M.includes(table, value, isArray)
 	local contains = false
 
-	for k in pairs(record) do
-		if k == key then
-			contains = true
-			break
+	if isArray then
+		for _, v in pairs(table) do
+			if v == value then
+				contains = true
+				break
+			end
+		end
+	else
+		for k in pairs(table) do
+			if k == value then
+				contains = true
+				break
+			end
 		end
 	end
 


### PR DESCRIPTION
- refactor: re-implement abstracted configuration options
- docs: update README.md
- write inline documentation for command functions and tables
- update command code documentations
- docs: finish inline documentation for ui file
- chore: update readme commands section
- add 'includes' utility function for object-like tables
- add window position values as constants
- create AnaloguePosition custom command
- fix: share fixed_position value with commands by storing it in command cache
- refactor: rename some variables and clean up functions
- fix: get rid of win_fixed_positions by adding function to return desired table
- fix: debug AnalogueReset functionality for other fixed positions
- chore: update README content
- add window fixed positions as array-table
- refactor: update includes utility function to support both object keys and array items
- feat: add :AnaloguePosition command to change clock's position in current neovim instance
- feat: implement :AnaloguePositionX command
- fix: preserve adjusted position after AnalogueReset execution
- feat: finish implementation of :AnaloguePositionY command
- fix: subtract lualine height from clock's position on y axis
